### PR TITLE
AndroidX libraries not found. Using correct and latest ones.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -90,12 +90,12 @@
 
     <!-- android -->
     <platform name="android">
-        <preference name="ANDROID_SUPPORT_V4_VERSION" default="26.+" />
+        <preference name="ANDROID_SUPPORT_V4_VERSION" default="28.+" />
         <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_V4_VERSION" />
         <framework src="src/android/build/localnotification.gradle" custom="true" type="gradleReference"/>
-         <!-- android x -->
-        <preference name="ANDROIDX_VERSION" default="1.2.0" />
-        <preference name="ANDROIDX_APPCOMPAT_VERSION" default="1.3.1" />
+        <!-- android x -->
+        <preference name="ANDROIDX_VERSION" default="1.0.0" />
+        <preference name="ANDROIDX_APPCOMPAT_VERSION" default="1.6.1" />
 
         <framework src="androidx.appcompat:appcompat:$ANDROIDX_APPCOMPAT_VERSION" />
 


### PR DESCRIPTION
The problem first appears when using this plugin in a Capacitor 5 project, where it works with AGP 8.0.2 (as of today).

When building with >= AGP 8.0, it searches for those libraries, but it cannot find the legacy:**1.2.0** in the repositories as the latest is **1.0.0** (https://developer.android.com/jetpack/androidx/releases/legacy).
This is taken from the **ANDROIDX_VERSION** variable. Using 1.0.0 fixes building errors.

At the same time, I updated the libraries to their latest version.